### PR TITLE
Allow a delete to proceed if file is locked by removing the associate…

### DIFF
--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -1276,7 +1276,28 @@ int ceph_posix_unlink(XrdOucEnv* env, const char *pathname) {
   if (0 == striper) {
     return -EINVAL;
   }
-  return striper->remove(file.name);
+  int rc = striper->remove(file.name);
+  if (rc != -EBUSY) {
+    return rc; 
+  }
+  // if EBUSY returned, assume the file is locked; so try to remove the lock
+  logwrapper((char*)"ceph_posix_unlink : unlink failed with -EBUSY %s, now trying to remove lock.", pathname);  
+
+  // lock name is only exposed in the libradosstriper source file, so hardcode it here. 
+  rc = ceph_posix_internal_removexattr(file, "lock.striper.lock");
+  if (rc !=0 ) {
+    logwrapper((char*)"ceph_posix_unlink : unlink rmxattr failed %s, %d", pathname, rc);
+    return rc;
+  }
+
+  // now try to remove again
+  rc = striper->remove(file.name);
+  if (rc != 0) {
+    logwrapper((char*)"ceph_posix_unlink : unlink failed after lock removal %s, %d", pathname, rc);
+  } else {
+    logwrapper((char*)"ceph_posix_unlink : unlink suceeded after lock removal %s, %d", pathname, rc);
+  }
+  return rc; 
 }
 
 DIR* ceph_posix_opendir(XrdOucEnv* env, const char *pathname) {


### PR DESCRIPTION
…d xattr metadata item. (#9)

In the case a file has an existing (stuck) lock, when the file is requested to be deleted, it will fail with -EBUSY. In this case we remove the lock and retry the unlink command.
This asserts therefore that a delete should take precedence over other activities.
As libradosstriper uses shared locks for both reads and writes, there is little chance to catch the few edge cases where this behaviour may be less desirable.
The lock removal is achieved through the removal of the lock extended attribute, using libradosstriper methods.

Co-authored-by: James Walder <james.walder@stfc.ac.uk>